### PR TITLE
Added before and after hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,31 @@ var options = {
   protocol: 'http',                 // optional, default: this.protocol
   host: 'www.risingstack.com'       // optional, default: this.host,
   prerenderToken: ''                // optional or process.env.PRERENDER_TOKEN
+  beforePrerender: function *() {   // optional before hook
+    this.body = 'foo';
+  },
+  afterPrerender: function *() {    // optional after hook
+    this.body = 'bar';
+  }
 };
 
 // Use as middleware
 app.use(prerender(options));
+
 ```
+> When prerendering happens the request will not yield further down the stack but return the rendered page instead.
+
+
+#### Hooks
+
+If `beforePrerender` or `afterPrerender` is set in the options, they will be called
+before and after the prerendering is supposed to happen. If `beforePrerender` sets a
+body, it will be used and the actual prerender server will **not be called** for that
+request.
+
+This makes it possible to reliably tell when a request was or is going to be prerendered and therefore the perfect place
+to handle caching if needed.
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-prerender",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added hooks (generators) to be able to reliably and nicely tell when prerendering is going to happen or already has happened since they are only yielded to if the respective situation happens.

The `afterPrerender` is pretty useless if we consider that whatever has `yield`ed to `koa-prerender` will have control back and always have access to the `X-Prerender` header and the context as well. I only added it for the sake of consistency.  

This makes it possible to cache the result and possibly save a decent amount of resources.

It will also no longer yield down the stack when prerendering happens. The reason for this is simple: it used to overwrite the body of the response anyway so letting it run down and up is just wasting resources. Any other things that are supposed to happen after it can now happen in the after hook, or in a middleware above it which will then have access to the `X-Prerender` header at all times.

This is technically a breaking change, but in truth it only affects those who relied on this yield down the stack for some reason. Nevertheless it **bumps the major**

Closes #11 
Possibly solves #9 
